### PR TITLE
fix: Keep the rewrites when next.config.js is an ES module

### DIFF
--- a/nsm/scripts/copy-nextjs-config.js
+++ b/nsm/scripts/copy-nextjs-config.js
@@ -2,32 +2,55 @@ const path = require("path")
 const prettier = require("prettier")
 const fs = require("fs/promises")
 const { existsSync } = require("fs")
+const { pathToFileURL } = require("url")
+
+// A module namespace is not the config, the config is its default export.
+// The require below returns a namespace for an ES module in two cases: since
+// Node.js 22.12 require of an ES module succeeds and returns one, and the nsm
+// bin registers esbuild-runner, which transpiles an ES module to CommonJS and
+// marks the result with __esModule. Reading the config off the namespace left
+// rewrites undefined, which silently dropped it from the generated config.
+const interopDefault = (value) => {
+  if (value == null) return value
+
+  const is_namespace =
+    value[Symbol.toStringTag] === "Module" || value.__esModule === true
+
+  return is_namespace && "default" in value ? value.default : value
+}
+
+async function loadNextjsConfig(nextConfigPath) {
+  let nextConfig
+  try {
+    nextConfig = interopDefault(require(nextConfigPath))
+  } catch (errorA) {
+    try {
+      nextConfig = interopDefault(await import(pathToFileURL(nextConfigPath)))
+    } catch (errorB) {
+      console.error(errorA)
+      console.error(errorB)
+      throw new Error(`Failed to load ${nextConfigPath}`)
+    }
+  }
+
+  if (typeof nextConfig === "function") {
+    nextConfig = await nextConfig()
+  }
+
+  // A module namespace is frozen, so resolve rewrites into a copy.
+  if (typeof nextConfig.rewrites === "function") {
+    nextConfig = { ...nextConfig, rewrites: await nextConfig.rewrites() }
+  }
+
+  return nextConfig
+}
 
 async function copyNextjsConfig() {
   const nextConfigPath = path.resolve(__dirname, "../../next.config.js")
 
-  let nextConfig = {}
-  if (existsSync(nextConfigPath)) {
-    try {
-      nextConfig = require(nextConfigPath)
-    } catch (errorA) {
-      try {
-        nextConfig = (await import(nextConfigPath)).default
-      } catch (errorB) {
-        console.error(errorA)
-        console.error(errorB)
-        throw new Error(`Failed to load ${nextConfigPath}`)
-      }
-    }
-
-    if (typeof nextConfig === "function") {
-      nextConfig = await nextConfig()
-    }
-
-    if (typeof nextConfig.rewrites === "function") {
-      nextConfig.rewrites = await nextConfig.rewrites()
-    }
-  }
+  const nextConfig = existsSync(nextConfigPath)
+    ? await loadNextjsConfig(nextConfigPath)
+    : {}
 
   const nextConfigFile = await prettier.format(
     `export default ${JSON.stringify(nextConfig)}`,
@@ -40,7 +63,7 @@ async function copyNextjsConfig() {
   )
 }
 
-module.exports = { copyNextjsConfig }
+module.exports = { copyNextjsConfig, loadNextjsConfig }
 
 if (require.main === module) {
   copyNextjsConfig()

--- a/tests/assets/next-configs/commonjs-function/next.config.js
+++ b/tests/assets/next-configs/commonjs-function/next.config.js
@@ -1,0 +1,13 @@
+module.exports = async () => ({
+  reactStrictMode: true,
+  async rewrites() {
+    return {
+      beforeFiles: [
+        {
+          source: "/:path*",
+          destination: "/api/:path*",
+        },
+      ],
+    }
+  },
+})

--- a/tests/assets/next-configs/commonjs/next.config.js
+++ b/tests/assets/next-configs/commonjs/next.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  reactStrictMode: true,
+  async rewrites() {
+    return {
+      beforeFiles: [
+        {
+          source: "/:path*",
+          destination: "/api/:path*",
+        },
+      ],
+    }
+  },
+}

--- a/tests/assets/next-configs/module/next.config.js
+++ b/tests/assets/next-configs/module/next.config.js
@@ -1,0 +1,13 @@
+export default {
+  reactStrictMode: true,
+  async rewrites() {
+    return {
+      beforeFiles: [
+        {
+          source: "/:path*",
+          destination: "/api/:path*",
+        },
+      ],
+    }
+  },
+}

--- a/tests/assets/next-configs/module/package.json
+++ b/tests/assets/next-configs/module/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "next-config-module-fixture",
+  "private": true,
+  "type": "module"
+}

--- a/tests/load-nextjs-config.test.ts
+++ b/tests/load-nextjs-config.test.ts
@@ -1,0 +1,40 @@
+import test from "ava"
+import { loadNextjsConfig } from "nsm/scripts/copy-nextjs-config"
+import path from "path"
+
+const configPath = (name: string) =>
+  path.resolve(__dirname, "assets", "next-configs", name, "next.config.js")
+
+const expected_rewrites = {
+  beforeFiles: [
+    {
+      source: "/:path*",
+      destination: "/api/:path*",
+    },
+  ],
+}
+
+test("loads a CommonJS config", async (t) => {
+  const config = await loadNextjsConfig(configPath("commonjs"))
+
+  t.true(config.reactStrictMode)
+  t.deepEqual(config.rewrites, expected_rewrites)
+})
+
+test("loads a CommonJS config exporting a function", async (t) => {
+  const config = await loadNextjsConfig(configPath("commonjs-function"))
+
+  t.true(config.reactStrictMode)
+  t.deepEqual(config.rewrites, expected_rewrites)
+})
+
+// The nsm bin registers esbuild-runner, which transpiles an ES module to
+// CommonJS, and require of an ES module returns a module namespace since
+// Node.js 22.12. Both give the require in loadNextjsConfig a namespace instead
+// of the config, and reading rewrites off the namespace silently dropped it.
+test("loads an ES module config", async (t) => {
+  const config = await loadNextjsConfig(configPath("module"))
+
+  t.true(config.reactStrictMode)
+  t.deepEqual(config.rewrites, expected_rewrites)
+})


### PR DESCRIPTION
## The bug

`copyNextjsConfig` loads `next.config.js` with a `require` and only falls back to `import` when that throws. For an ES module config the `require` no longer throws, and returns a module namespace rather than the config, in two cases:

- Since Node.js 22.12, `require` of an ES module succeeds and returns a namespace.
- The `nsm` bin registers `esbuild-runner`, which hooks `.js` outside `node_modules` and transpiles an ES module to CommonJS, marking the result with `__esModule`.

`typeof nextConfig.rewrites === "function"` is then false on the namespace, so `rewrites` is dropped from the generated `.nsm/next.config.ts`. There is no error — the build succeeds and the config comes out as:

```js
export default { default: { /* ... */ } }
```

A project that relies on a rewrite to reach its routes then **404s on every request** with nothing to explain it. This is what `seamapi/fake-seam-connect` hit when moving to Node.js 22.

## The fix

Unwrap the default export whenever a namespace is loaded, whichever way it was loaded — `Symbol.toStringTag === "Module"` covers Node's namespace, `__esModule` covers esbuild's CommonJS output, and the `import` fallback goes through the same unwrap.

Two smaller correctness fixes in the same function:

- Resolve `rewrites` into a copy of the config. A module namespace is frozen, so assigning onto it fails.
- Pass a file URL to the `import` fallback, so it also resolves on Windows.

## Tests

The loading is extracted into an exported `loadNextjsConfig` so it can be tested directly, with fixtures for a CommonJS object config, a CommonJS function config and an ES module config. The sample project used by the existing tests has a CommonJS config, which is why this path was never covered.

The new ES module test fails on `main` and passes with this change. All 12 tests pass, and `prettier --check` is clean.

Verified end to end against `seamapi/fake-seam-connect` on Node.js 22.22: with this fix and no workaround in the consumer, `nsm build` emits the rewrites correctly and the routes resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6bQ6zQqwT1vq9NkrG1UTm

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6bQ6zQqwT1vq9NkrG1UTm)_